### PR TITLE
Fix code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/plugins/download.js
+++ b/plugins/download.js
@@ -1,5 +1,6 @@
 const config = require('../config');
 const { bot, getJson, postJson, toAudio, toPTT, getBuffer, convertToWebP } = require('../lib');
+const urlLib = require('url');
 bot(
  {
   pattern: 'spotify ?(.*)',
@@ -86,7 +87,10 @@ bot(
   type: 'download',
  },
  async (message, match, m, client) => {
-  if (!match || !match.includes('drive.google.com')) return await message.reply('_Provide Google Drive File Url_');
+  if (!match) return await message.reply('_Provide Google Drive File Url_');
+  const parsedUrl = urlLib.parse(match.trim());
+  const allowedHosts = ['drive.google.com'];
+  if (!allowedHosts.includes(parsedUrl.host)) return await message.reply('_Provide Google Drive File Url_');
   await message.sendReply('_Downloading_');
   const res = await getJson(`https://giftedapis.us.kg/api/download/gdrivedl?url=${encodeURIComponent(match.trim())}&apikey=gifted`);
   return await message.send(res.result.download);


### PR DESCRIPTION
Fixes [https://github.com/AstroX10/whatsapp-bot/security/code-scanning/8](https://github.com/AstroX10/whatsapp-bot/security/code-scanning/8)

To fix the problem, we need to parse the URL and check the host explicitly against a whitelist of allowed hosts. This ensures that the host is exactly what we expect and not a substring embedded in a different part of the URL.

- Use the `url` module to parse the URL and extract the host.
- Compare the extracted host against a whitelist of allowed hosts.
- Update the relevant lines in the `plugins/download.js` file to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
